### PR TITLE
Fix normalize and divide

### DIFF
--- a/pybbn/graph/potential.py
+++ b/pybbn/graph/potential.py
@@ -132,9 +132,12 @@ class PotentialUtil(object):
         :return: Potential.
         """
         total = sum([entry.value for entry in potential.entries])
-        for entry in potential.entries:
-            d = entry.value / total
-            entry.value = d
+
+        if total != 0.0:
+            for entry in potential.entries:
+                d = entry.value / total
+                entry.value = d
+
         return potential
 
     @staticmethod

--- a/pybbn/graph/potential.py
+++ b/pybbn/graph/potential.py
@@ -149,15 +149,14 @@ class PotentialUtil(object):
         :return: Potential.
         """
         potential = Potential()
-        for entry in numerator.entries:
-            if len(denominator.entries) > 0:
-                e = denominator.entries[0]
-                d = 0.0 \
-                    if PotentialUtil.is_zero(entry.value) or PotentialUtil.is_zero(e.value) \
-                    else (entry.value / e.value)
-                new_entry = entry.duplicate()
-                new_entry.value = d
-                potential.add_entry(new_entry)
+        for i, entry in enumerate(numerator.entries):
+            e = denominator.entries[i]
+            d = 0.0 \
+                if PotentialUtil.is_zero(entry.value) or PotentialUtil.is_zero(e.value) \
+                else (entry.value / e.value)
+            new_entry = entry.duplicate()
+            new_entry.value = d
+            potential.add_entry(new_entry)
         return potential
 
     @staticmethod


### PR DESCRIPTION
I was attempting to use this library to implement a simple static discrete BBN with a single root node and a few leaves.  When I made a hard observation, I was encountering crashes.

Upon investigating, it appeared that normalize did not handle the case where the potentials would sum to zero (I would get a divide by zero error).  I make a change to handle this by testing for that condition and not attempting to normalize in this case, since any amount of scaling would still result in a sum of zero.

After making this change, I noticed that some marginal probabilities did not match my manual calculations.  Further investigation showed that the divide routine was only using the first entry for the denominator.  I changed the code to walk through both the numerator and denominator, which I believe is correct.  The resulting code produced the answers I expected for the simple BBN.

The following example works correctly with these changes:

```
from pybbn.graph.dag import Bbn
from pybbn.graph.edge import Edge, EdgeType
from pybbn.graph.jointree import EvidenceBuilder
from pybbn.graph.node import BbnNode
from pybbn.graph.variable import Variable
from pybbn.pptc.inferencecontroller import InferenceController

def print_root_marginals(jt):
    n = jt.get_bbn_node_by_name('Root Node')
    print("Root Node Probabilities:")
    for e in jt.get_bbn_potential(n).entries:
        print('    {:40}: {:1.3f}'.format(e.entries[0], e.value))

def print_leaf_marginals(jt, nodes):
    print("Leaf Node probability of being present:")
    potentials = {n: jt.get_bbn_potential(n).entries[0].value for n in [jt.get_bbn_node_by_name(x) for x in nodes]
                  if n.variable.name != 'Root Node'}
    for n in sorted(potentials, key=lambda x: potentials[x], reverse=True):
        print('{:9}: {:1.3f}'.format(n.variable.name, potentials[n]))

def main():
    counts = { 'a': {'x': 34, 'y': 26},
               'b': {'x': 16, 'z': 55},
               'c': {'w': 40}}

    totals = { x : sum(counts[x][y] for y in counts[x]) for x in counts }

    all_root_states = list(sorted(counts))
    all_leaf_nodes = list(sorted({leaf for rs in counts for leaf in counts[rs]}))

    # Build the network structure
    root = BbnNode(Variable(0, 'Root Node', all_root_states), [1 / len(all_root_states)] * len(all_root_states))
    bbn = Bbn().add_node(root)
    for i, leaf in enumerate(all_leaf_nodes):
        n = BbnNode(Variable(i + 1, leaf, ['present', 'absent']),
                    [f(counts[rs][leaf] / totals[rs] if leaf in counts[rs] else 0.0) for rs in all_root_states for f in
                     [lambda x: x, lambda x: 1.0 - x]])
        bbn = bbn.add_node(n).add_edge(Edge(root, n, EdgeType.DIRECTED))

    # Convert bbn to join tree
    jt = InferenceController.apply(bbn)

    # Dump root marginals and leaf marginals
    print_root_marginals(jt)
    print_leaf_marginals(jt, nodes=all_leaf_nodes)

    # Look at beliefs, given each root state
    for rs in all_root_states:
        n = jt.get_bbn_node_by_name('Root Node')
        ev = EvidenceBuilder().with_node(n).with_evidence(rs, 1.0).build()
        jt.set_observation(ev)

        print('-' * 72)
        print('Setting root state {} to True'.format(rs))
        print_root_marginals(jt)
        print_leaf_marginals(jt, nodes=all_leaf_nodes)
        print()
        jt.unobserve_all()

    # Set individual leaf nodes to present and observe the root node
    for leaf in all_leaf_nodes:
        n = jt.get_bbn_node_by_name(leaf)
        ev = EvidenceBuilder().with_node(n).with_evidence('present', 1.0).build()
        jt.set_observation(ev)

        print('-' * 72)
        print('Setting leaf node {} to present'.format(leaf))
        print_root_marginals(jt)
        print_leaf_marginals(jt, nodes=all_leaf_nodes)
        print()
        jt.unobserve_all()


if __name__ == '__main__':
    main()
```

This produces the following output:

```
Root Node Probabilities:
    a                                       : 0.333
    b                                       : 0.333
    c                                       : 0.333
Leaf Node probability of being present:
w        : 0.333
x        : 0.264
z        : 0.258
y        : 0.144
------------------------------------------------------------------------
Setting root state a to True
Root Node Probabilities:
    a                                       : 1.000
    b                                       : 0.000
    c                                       : 0.000
Leaf Node probability of being present:
x        : 0.567
y        : 0.433
w        : 0.000
z        : 0.000

------------------------------------------------------------------------
Setting root state b to True
Root Node Probabilities:
    a                                       : 0.000
    b                                       : 1.000
    c                                       : 0.000
Leaf Node probability of being present:
z        : 0.775
x        : 0.225
w        : 0.000
y        : 0.000

------------------------------------------------------------------------
Setting root state c to True
Root Node Probabilities:
    a                                       : 0.000
    b                                       : 0.000
    c                                       : 1.000
Leaf Node probability of being present:
w        : 1.000
x        : 0.000
y        : 0.000
z        : 0.000

------------------------------------------------------------------------
Setting leaf node w to present
Root Node Probabilities:
    a                                       : 0.000
    b                                       : 0.000
    c                                       : 1.000
Leaf Node probability of being present:
w        : 1.000
x        : 0.000
y        : 0.000
z        : 0.000

------------------------------------------------------------------------
Setting leaf node x to present
Root Node Probabilities:
    a                                       : 0.715
    b                                       : 0.285
    c                                       : 0.000
Leaf Node probability of being present:
x        : 1.000
z        : 0.554
y        : 0.217
w        : 0.000

------------------------------------------------------------------------
Setting leaf node y to present
Root Node Probabilities:
    a                                       : 1.000
    b                                       : 0.000
    c                                       : 0.000
Leaf Node probability of being present:
y        : 1.000
x        : 0.567
w        : 0.000
z        : 0.000

------------------------------------------------------------------------
Setting leaf node z to present
Root Node Probabilities:
    a                                       : 0.000
    b                                       : 1.000
    c                                       : 0.000
Leaf Node probability of being present:
z        : 1.000
x        : 0.225
w        : 0.000
y        : 0.000
```

Prior to making the proposed changes, normalize would crash with a divide-by-zero error.  Also, probabilities were not correct for variable `z` when evidence `Root Node = b` was entered.  This was due to only using the first entry in the denominator in the divide routine.

After making these changes, I ran all of the tests provided with this project and they pass.  I did not offer an additional regression test, as I wasn't sure how you would like that to be structured.